### PR TITLE
Improve discovery

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -10,6 +10,7 @@ spec:
   source:
     path: "."
     plugin:
+      name: tanka
       env:
         - name: TK_ENV
           value: default

--- a/app.yaml
+++ b/app.yaml
@@ -10,7 +10,6 @@ spec:
   source:
     path: "."
     plugin:
-      name: tanka
       env:
         - name: TK_ENV
           value: default

--- a/custom-values.yaml
+++ b/custom-values.yaml
@@ -14,6 +14,8 @@ configs:
             - "sh"
             - "-c"
             - "tk show environments/${ARGOCD_ENV_TK_ENV} --dangerous-allow-redirect"
+        discover:
+          fileName: "jsonnetfile.json"
 repoServer:
   extraContainers:
   - name: tanka

--- a/custom-values.yaml
+++ b/custom-values.yaml
@@ -14,8 +14,6 @@ configs:
             - "sh"
             - "-c"
             - "tk show environments/${ARGOCD_ENV_TK_ENV} --dangerous-allow-redirect"
-        discover:
-          fileName: "*"
 repoServer:
   extraContainers:
   - name: tanka


### PR DESCRIPTION
I wanted to specify the plugin name explicitly and not have discovery, but it all went wrong.

All we have now is a more specific type of file that must be present for the tanka plugin to be used.