### PR TITLE
Demonstrate inability to reference sidecar plugin

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -10,6 +10,7 @@ spec:
   source:
     path: "tanka"
     plugin:
+      name: tanka
       env:
         - name: TK_ENV
           value: default

--- a/app.yaml
+++ b/app.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     path: "tanka"
     plugin:
-      name: tanka
+      name: tanka-v1.0
       env:
         - name: TK_ENV
           value: default


### PR DESCRIPTION
Got advice on how to fix the problem.

If you specify a version for your sidecar plugin, the name is NAME-VERSION.